### PR TITLE
CDPSDX-3112 fix cross account role accountId validation

### DIFF
--- a/cdpctl/validation/infra/validate_aws_cross_account_role.py
+++ b/cdpctl/validation/infra/validate_aws_cross_account_role.py
@@ -97,9 +97,13 @@ def aws_cross_account_role_account_id_validation(
     ]:
         if "Principal" in s.keys():
             if "AWS" in s["Principal"].keys():
-                for arn in s["Principal"]["AWS"]:
-                    if str(account_id) in arn.split(":"):
+                if isinstance(s["Principal"]["AWS"], str):
+                    if str(account_id) in s["Principal"]["AWS"].split(":"):
                         found_account_id = True
+                else:
+                    for arn in s["Principal"]["AWS"]:
+                        if str(account_id) in arn.split(":"):
+                            found_account_id = True
 
     if not found_account_id:
         pytest.fail("Account id not in cross account role", False)

--- a/cdpctl/validation/infra/validate_aws_cross_account_role.py
+++ b/cdpctl/validation/infra/validate_aws_cross_account_role.py
@@ -95,15 +95,14 @@ def aws_cross_account_role_account_id_validation(
     for s in cross_account_role_data["role"]["Role"]["AssumeRolePolicyDocument"][
         "Statement"
     ]:
-        if "Principal" in s.keys():
-            if "AWS" in s["Principal"].keys():
-                if isinstance(s["Principal"]["AWS"], str):
-                    if str(account_id) in s["Principal"]["AWS"].split(":"):
+        if "Principal" in s and "AWS" in s["Principal"]:
+            if isinstance(s["Principal"]["AWS"], str):
+                if str(account_id) in s["Principal"]["AWS"].split(":"):
+                    found_account_id = True
+            else:
+                for arn in s["Principal"]["AWS"]:
+                    if str(account_id) in arn.split(":"):
                         found_account_id = True
-                else:
-                    for arn in s["Principal"]["AWS"]:
-                        if str(account_id) in arn.split(":"):
-                            found_account_id = True
 
     if not found_account_id:
         pytest.fail("Account id not in cross account role", False)


### PR DESCRIPTION
    current accountId validation expects list of arns
    but if there is only one account api returns a string
    and not list hence validation is failing.

    Changed validation to check type of arn(s) and then
    proceed with validation. Changes verified in dev env.

Signed-off-by: Mahendra Korepu <mkorepu@cloudera.com>