### PR TITLE
CDPCAM-72: Added warnings support

### DIFF
--- a/cdpctl/validation/__init__.py
+++ b/cdpctl/validation/__init__.py
@@ -194,12 +194,14 @@ class Context:
         self.validation_name = None
         self.function = None
         self.nodeid = None
+        self.state = None
 
     def clear(self) -> None:
         """Clear all the context values."""
         self.validation_name = None
         self.function = None
         self.nodeid = None
+        self.state = None
 
 
 current_context: Context = Context()
@@ -222,6 +224,11 @@ def validator(func):
 def _add_issue(issue_type: IssueType, issue: Issue):
     """Add an Issue to the selected type for the current validation."""
     context = current_context
+    if not context.state:
+        context.state = issue_type
+    elif issue_type == IssueType.PROBLEM and context.state == IssueType.WARNING:
+        context.state = IssueType.PROBLEM
+
     if context.validation_name not in get_issues():
         get_issues()[context.validation_name] = {
             IssueType.PROBLEM.value: [],

--- a/cdpctl/validation/conftest.py
+++ b/cdpctl/validation/conftest.py
@@ -55,7 +55,7 @@ from pytest import Collector, ExitCode, Item, Session
 
 from cdpctl.utils import load_config
 
-from . import UnrecoverableValidationError, current_context, get_config_value
+from . import IssueType, UnrecoverableValidationError, current_context, get_config_value
 
 this = sys.modules[__name__]
 this.config_file = "config.yaml"
@@ -94,13 +94,12 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> TestReport:
             current_context.nodeid = item.nodeid
             click.echo(suf, nl=False, err=True)
     elif call.when == "call":  # Validation was called
-        if result.passed:
-            # All good
-            click.echo(f" {emoji.emojize(':check_mark:')}", err=True)
-        elif result.failed:
-            # Catch any issues
+        if current_context.state == IssueType.PROBLEM:
             click.echo(f" {emoji.emojize(':cross_mark:')}", err=True)
-            # item.session.issues[item] = str(result.longrepr.chain[-1][0])
+        elif current_context.state == IssueType.WARNING:
+            click.echo(f" {emoji.emojize(':red_exclamation_mark:')}", err=True)
+        else:
+            click.echo(f" {emoji.emojize(':check_mark:')}", err=True)
     elif call.when == "teardown":
         this.run_validations += 1
     sys.stdout.flush()

--- a/cdpctl/validation/infra/issue_templates.yml
+++ b/cdpctl/validation/infra/issue_templates.yml
@@ -159,7 +159,7 @@ render_type: list
 docs_link: https://docs.cloudera.com/cdp/latest/requirements-aws/topics/mc-aws-req-vpc.html
 ---
 id: AWS_DNS_SUPPORT_NOT_ENABLED_FOR_VPC
-summary: "DNS support is not enabled for VPC id {0}"
+summary: "DNS support is not enabled for VPC id {0}, this is needed to run the Data Engineering, DataFlow, Data Warehouse, or Machine Learning experiences."
 docs_link: https://docs.cloudera.com/cdp/latest/requirements-aws/topics/mc-aws-req-vpc.html
 ---
 id: AWS_VPC_NOT_FOUND_IN_ACCOUNT

--- a/cdpctl/validation/infra/validate_aws_subnets.py
+++ b/cdpctl/validation/infra/validate_aws_subnets.py
@@ -46,7 +46,7 @@ from typing import Any, Dict, List
 import pytest
 from boto3_type_annotations.iam import Client as EC2Client
 
-from cdpctl.validation import fail, get_config_value
+from cdpctl.validation import fail, get_config_value, warn
 from cdpctl.validation.aws_utils import get_client
 from cdpctl.validation.infra.issues import (
     AWS_DNS_SUPPORT_NOT_ENABLED_FOR_VPC,
@@ -233,7 +233,7 @@ def aws_public_subnets_tags_validation() -> None:
         subnet_missing_tags = [k for k, v in subnets_w_valid_tag.items() if not v]
 
         if len(subnet_missing_tags) > 0:
-            fail(
+            warn(
                 AWS_SUBNETS_MISSING_K8S_LB_TAG,
                 subjects=["Public"],
                 resources=subnet_missing_tags,
@@ -405,7 +405,7 @@ def aws_private_subnets_tags_validation() -> None:
         subnet_missing_tags = [k for k, v in subnets_w_valid_tag.items() if not v]
 
         if len(subnet_missing_tags) > 0:
-            fail(
+            warn(
                 AWS_SUBNETS_MISSING_K8S_LB_TAG,
                 subjects=["Private"],
                 resources=subnet_missing_tags,
@@ -458,7 +458,7 @@ def aws_vpc_subnets_validation(
         )["EnableDnsHostnames"]["Value"]
 
         if not (enable_dns_hostnames and enable_dns_support):
-            fail(AWS_DNS_SUPPORT_NOT_ENABLED_FOR_VPC, subjects=[vpc_id])
+            warn(AWS_DNS_SUPPORT_NOT_ENABLED_FOR_VPC, subjects=[vpc_id])
     except KeyError as e:
         fail(AWS_REQUIRED_DATA_MISSING, e.args[0])
     except ec2_client.exceptions.ClientError as ce:

--- a/cdpctl/validation/renderer/templates/text.j2
+++ b/cdpctl/validation/renderer/templates/text.j2
@@ -18,7 +18,7 @@ Problems Found:
 {%- endif -%}
 {% endfor %}
 {%- endif %}
-{% if issue_types["warning"]|length %}
+{%- if issue_types["warning"]|length -%}
 Warnings Found:
 {% for warning in issue_types["warning"] -%}
 * {{warning.message}}

--- a/tests/validation/infra/test_validate_aws_subnets.py
+++ b/tests/validation/infra/test_validate_aws_subnets.py
@@ -61,7 +61,11 @@ from cdpctl.validation.infra.validate_aws_subnets import (
     aws_public_subnets_validation,
     aws_vpc_subnets_validation,
 )
-from tests.validation import expect_validation_failure, expect_validation_success
+from tests.validation import (
+    expect_validation_failure,
+    expect_validation_success,
+    expect_validation_warning,
+)
 
 sample_public_subnets_response = {
     "Subnets": [
@@ -518,7 +522,7 @@ def test_aws_public_subnets_tags_validation_success(ec2_client: EC2Client) -> No
         func()
 
 
-def test_aws_public_subnets_tags_validation_failure(ec2_client: EC2Client) -> None:
+def test_aws_public_subnets_tags_validation_warning(ec2_client: EC2Client) -> None:
     """Unit test public subnets tags failure."""
     config = get_config(public_subnet_ids, "fail")
     stubber = Stubber(ec2_client)
@@ -554,7 +558,7 @@ def test_aws_public_subnets_tags_validation_failure(ec2_client: EC2Client) -> No
         func = expect_validation_success(aws_public_subnets_validation)
         func(config, ec2_client)
     with stubber:
-        func = expect_validation_failure(aws_public_subnets_tags_validation)
+        func = expect_validation_warning(aws_public_subnets_tags_validation)
         func()
 
 
@@ -933,7 +937,7 @@ def test_aws_private_subnets_tags_validation_failure(ec2_client: EC2Client) -> N
         func = expect_validation_success(aws_private_subnets_validation)
         func(config, ec2_client)
     with stubber:
-        func = expect_validation_failure(aws_private_subnets_tags_validation)
+        func = expect_validation_warning(aws_private_subnets_tags_validation)
         func()
 
 


### PR DESCRIPTION
This commit adds warnings support in the validations
output as well for the testing.  It also changes some
experience specific validations to warnings.

Signed-off-by: Brian Towles <btowles@cloudera.com>